### PR TITLE
Adds skipping of build to pipeline deploy step as is redundant.

### DIFF
--- a/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
@@ -51,15 +51,14 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
           app_location: "build/web/wwwroot"
-          output_location: ''
           api_location: "build/api"
           skip_app_build: true
           skip_api_build: true
-          config_file_location: "/"
+          config_file_location: "."
 
 
   close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     steps:

--- a/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
@@ -23,7 +23,7 @@ jobs:
       (github.event_name == 'pull_request' && github.event.action != 'closed')
     name: Build and Deploy Job
     outputs:
-      deploy_url: ${{ steps.builddeploy.outputs.static_web_app_url }}
+      deploy_url: ${{ steps.deploy_swa.outputs.static_web_app_url }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
@@ -36,8 +36,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'global.json', 'NuGet.config') }}
           restore-keys: ${{ runner.os }}-nuget-
+
+      - name: Restore .NET solution dependencies
+        run: |
+          dotnet restore src/Web/Web.csproj
+          dotnet restore src/Api/Api.csproj
 
       - name: Build & publish Blazor WASM frontend project
         run: dotnet publish src/Web/Web.csproj -c Release -o build/web

--- a/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
@@ -48,7 +48,9 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_AGREEABLE_RIVER_007F2F303 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
+          skip_app_build: true
           app_location: "build/web/wwwroot"
+          skip_api_build: true
           api_location: "build/api"
 
 

--- a/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
@@ -6,6 +6,9 @@ on:
       deploy_url:
         description: 'The URL of the deployed Static Web App'
         value: ${{ jobs.build_and_deploy_job.outputs.deploy_url }}
+      healthcheck_url:
+        description: 'The URL of the deployed Static Web App API healthcheck endpoint'
+        value: ${{ jobs.build_and_deploy_job.outputs.deploy_url }}api/healthcheck
   push:
     branches:
       - main
@@ -67,6 +70,11 @@ jobs:
           skip_app_build: true
           skip_api_build: true
           config_file_location: "."
+
+      - name: Output site URLs
+        run: |
+          echo "Frontend URL: ${{ steps.deploy_swa.outputs.static_web_app_url }}"
+          echo "API healthcheck URL: ${{ steps.deploy_swa.outputs.static_web_app_url }}api/healthcheck"
 
 
   close_pull_request_job:

--- a/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
@@ -8,7 +8,7 @@ on:
         value: ${{ jobs.build_and_deploy_job.outputs.deploy_url }}
       healthcheck_url:
         description: 'The URL of the deployed Static Web App API healthcheck endpoint'
-        value: ${{ jobs.build_and_deploy_job.outputs.deploy_url }}api/healthcheck
+        value: ${{ jobs.build_and_deploy_job.outputs.deploy_url }}/api/healthcheck
   push:
     branches:
       - main
@@ -74,7 +74,7 @@ jobs:
       - name: Output site URLs
         run: |
           echo "Frontend URL: ${{ steps.deploy_swa.outputs.static_web_app_url }}"
-          echo "API healthcheck URL: ${{ steps.deploy_swa.outputs.static_web_app_url }}api/healthcheck"
+          echo "API healthcheck URL: ${{ steps.deploy_swa.outputs.static_web_app_url }}/api/healthcheck"
 
 
   close_pull_request_job:

--- a/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
@@ -32,16 +32,18 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      # Build Blazor WASM
-      - name: Publish Blazor WASM
+      - name: Build & publish Blazor WASM frontend project
         run: dotnet publish src/Web/Web.csproj -c Release -o build/web
 
-      # Build Azure Function API (isolated worker)
-      - name: Publish API
+      - name: Build & publish Azure Function API (isolated worker)
         run: dotnet publish src/Api/Api.csproj -c Release -o build/api
 
-      # Deploy to Azure Static Web Apps
-      - name: Build And Deploy
+      - name: Verify published artifacts exist
+        run: |
+          test -f build/web/wwwroot/index.html
+          test -f build/api/host.json
+
+      - name: Deploy built artifacts to Azure Static Web App resource
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
         with:

--- a/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
@@ -44,7 +44,7 @@ jobs:
           test -f build/api/host.json
 
       - name: Deploy built artifacts to Azure Static Web App resource
-        id: builddeploy
+        id: deploy_swa
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_AGREEABLE_RIVER_007F2F303 }}
@@ -64,7 +64,7 @@ jobs:
     name: Close Pull Request Job
     steps:
       - name: Close Pull Request
-        id: closepullrequest
+        id: close_pull_request
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_AGREEABLE_RIVER_007F2F303 }}

--- a/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
@@ -32,6 +32,13 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: ${{ runner.os }}-nuget-
+
       - name: Build & publish Blazor WASM frontend project
         run: dotnet publish src/Web/Web.csproj -c Release -o build/web
 

--- a/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-river-007f2f303.yml
@@ -48,10 +48,12 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_AGREEABLE_RIVER_007F2F303 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
-          skip_app_build: true
           app_location: "build/web/wwwroot"
-          skip_api_build: true
+          output_location: ''
           api_location: "build/api"
+          skip_app_build: true
+          skip_api_build: true
+          config_file_location: "/"
 
 
   close_pull_request_job:

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,0 +1,5 @@
+{
+  "platform": {
+    "apiRuntime": "dotnet-isolated:8.0"
+  }
+}

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,5 +1,11 @@
 {
   "platform": {
     "apiRuntime": "dotnet-isolated:8.0"
+  },
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": [
+      "/api/*"
+    ]
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Public API healthcheck URL is now exposed so service status can be checked directly.

- Chores
  - Deployment now verifies pre-built frontend and API artifacts and uploads them without rebuilding, speeding releases.
  - Hosting runtime updated to .NET isolated 8.0.
  - Deployment outputs frontend and API URLs for easier access and faster availability of updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->